### PR TITLE
Icon inside of omnibox now is rounded

### DIFF
--- a/Mod/sources/address-bar.css
+++ b/Mod/sources/address-bar.css
@@ -414,6 +414,10 @@ span.OmniLinkItem-Details {
   padding         : 6px;
 }
 
+.OmniLinkItem-Favicon > *{
+  border-radius   : 100%;
+}
+
 .UrlBar-AddressField>.toolbar-insideinput:first-child,
 .UrlBar-AddressField>.toolbar-insideinput:nth-child(2) {
   position: absolute;


### PR DESCRIPTION
When you type in the omnibox and an address has a square Favicon looks bad.
With this fix, the favicon is rounded.